### PR TITLE
fix: update KBS example to use correct kb.assert() pattern

### DIFF
--- a/examples/kbs_strategy_example.rb
+++ b/examples/kbs_strategy_example.rb
@@ -77,7 +77,7 @@ custom_strategy.add_rule :aggressive_buy do
   on :stochastic, { zone: :oversold }
   on :bollinger, { position: :below }
   perform do
-    assert(:signal, {
+    kb.assert(:signal, {
       action: :buy,
       confidence: :high,
       reason: :triple_confirmation
@@ -90,7 +90,7 @@ custom_strategy.add_rule :conservative_sell do
   on :rsi, { level: :overbought }
   on :trend, { short_term: :down }
   perform do
-    assert(:signal, {
+    kb.assert(:signal, {
       action: :sell,
       confidence: :medium,
       reason: :overbought_downtrend
@@ -103,7 +103,7 @@ custom_strategy.add_rule :volume_breakout do
   on :trend, { short_term: :up, strength: :strong }
   on :volume, { level: :high }
   perform do
-    assert(:signal, {
+    kb.assert(:signal, {
       action: :buy,
       confidence: :high,
       reason: :volume_breakout
@@ -169,7 +169,7 @@ interactive_strategy.add_rule :golden_opportunity do
 
   # Action
   perform do
-    assert(:signal, {
+    kb.assert(:signal, {
       action: :buy,
       confidence: :high,
       reason: :golden_opportunity,
@@ -187,7 +187,7 @@ interactive_strategy.add_rule :disaster_warning do
   on :trend, { short_term: :down }
 
   perform do
-    assert(:signal, {
+    kb.assert(:signal, {
       action: :sell,
       confidence: :high,
       reason: :disaster_warning,


### PR DESCRIPTION
Updated examples/kbs_strategy_example.rb to use kb.assert() instead of assert() in perform blocks, matching the documented pattern in the KBS strategy implementation.

Changes:
- Fixed 5 perform blocks to use kb.assert() instead of assert()
- Ensures example code matches working implementation
- Pattern documented in lib/sqa/strategy/kbs_strategy.rb:88-91