### PR TITLE
fix: use Polars.col() for DataFrame filtering expression

### DIFF
--- a/lib/sqa/data_frame/alpha_vantage.rb
+++ b/lib/sqa/data_frame/alpha_vantage.rb
@@ -66,7 +66,8 @@ class SQA::DataFrame
 
       # Handle date criteria if applicable
       if from_date
-        df = df.filter(df["timestamp"].gt_eq(from_date.to_s))
+        # Use Polars.col() to create an expression for filtering
+        df = df.filter(Polars.col("timestamp") >= from_date.to_s)
       end
 
       # Wrap in SQA::DataFrame with proper transformers


### PR DESCRIPTION
Fixed Polars API usage error when filtering by date in AlphaVantage adapter.

Problem:
  df.filter(df["timestamp"].gt_eq(from_date.to_s))

Error:
  undefined method 'gt_eq' for an instance of Polars::Series

Root Cause:
- df["timestamp"] returns a Polars::Series (concrete data)
- .filter() expects a Polars::Expr (lazy expression)
- Series doesn't have comparison methods like .gt_eq()

Solution:
  df.filter(Polars.col("timestamp") >= from_date.to_s)

- Polars.col("timestamp") creates an expression
- Expressions support comparison operators (>=, <=, ==, etc.)
- This is the correct Polars API for filtering

Impact:
- Fixes incremental updates when cached data exists
- Allows filtering to only fetch data newer than last cached date
- update_dataframe_with_recent_data() now works correctly