### PR TITLE
fix: use 'timestamp' column instead of 'date' in SeasonalAnalyzer and…

### DIFF
--- a/lib/sqa/seasonal_analyzer.rb
+++ b/lib/sqa/seasonal_analyzer.rb
@@ -26,7 +26,7 @@ module SQA
         df = stock.df
 
         # Extract dates and prices
-        dates = df["date"].to_a.map { |d| Date.parse(d.to_s) }
+        dates = df["timestamp"].to_a.map { |d| Date.parse(d.to_s) }
         prices = df["adj_close_price"].to_a
 
         # Calculate monthly returns
@@ -52,7 +52,7 @@ module SQA
       #
       def filter_by_months(stock, months)
         df = stock.df
-        dates = df["date"].to_a.map { |d| Date.parse(d.to_s) }
+        dates = df["timestamp"].to_a.map { |d| Date.parse(d.to_s) }
         prices = df["adj_close_price"].to_a
 
         indices = []

--- a/lib/sqa/strategy_generator.rb
+++ b/lib/sqa/strategy_generator.rb
@@ -280,7 +280,7 @@ module SQA
       puts
 
       prices = @stock.df["adj_close_price"].to_a
-      dates = @stock.df["date"].to_a.map { |d| Date.parse(d.to_s) }
+      dates = @stock.df["timestamp"].to_a.map { |d| Date.parse(d.to_s) }
 
       validated_patterns = []
       validation_results = []
@@ -423,7 +423,7 @@ module SQA
         end
 
         # Add discovery period
-        dates = @stock.df["date"].to_a
+        dates = @stock.df["timestamp"].to_a
         pattern.context.discovered_period = "#{dates.first} to #{dates.last}"
       end
 


### PR DESCRIPTION
… StrategyGenerator

Multiple modules were trying to access a 'date' column that doesn't exist. The DataFrame uses 'timestamp' as the column name for date values.

Fixed in:
- SeasonalAnalyzer.analyze() - line 29
- SeasonalAnalyzer.filter_by_months() - line 55
- StrategyGenerator.walk_forward_validate() - line 283
- StrategyGenerator.discover_context_aware_patterns() - line 426

This was causing "not found: 'date' not found" errors when running seasonal analysis and context-aware pattern discovery.

All date column references now correctly use 'timestamp'.

Fixes: "not found: 'date' not found" error in seasonal analysis