### PR TITLE
feat: Add time period filtering to Sinatra app (30/60/90 days, quarters)

### DIFF
--- a/examples/sinatra_app/app.rb
+++ b/examples/sinatra_app/app.rb
@@ -35,6 +35,47 @@ helpers do
   def format_number(value)
     value.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
   end
+
+  # Filter data arrays by time period
+  # period can be: "30d", "60d", "90d", "1q", "2q", "3q", "4q", "all"
+  def filter_by_period(dates, *data_arrays, period: 'all')
+    return [dates, *data_arrays] if period == 'all' || dates.empty?
+
+    require 'date'
+
+    # Parse dates (they're strings in YYYY-MM-DD format)
+    parsed_dates = dates.map { |d| Date.parse(d) }
+    latest_date = parsed_dates.max
+
+    # Calculate cutoff date based on period
+    cutoff_date = case period
+                  when '30d'
+                    latest_date - 30
+                  when '60d'
+                    latest_date - 60
+                  when '90d'
+                    latest_date - 90
+                  when '1q'
+                    latest_date - 63  # ~3 months = 1 quarter (63 trading days)
+                  when '2q'
+                    latest_date - 126 # ~6 months = 2 quarters
+                  when '3q'
+                    latest_date - 189 # ~9 months = 3 quarters
+                  when '4q'
+                    latest_date - 252 # ~12 months = 4 quarters
+                  else
+                    parsed_dates.min # "all" - keep everything
+                  end
+
+    # Find indices where date >= cutoff_date
+    indices = parsed_dates.each_with_index.select { |d, i| d >= cutoff_date }.map(&:last)
+
+    # Filter all arrays by the same indices
+    filtered_dates = indices.map { |i| dates[i] }
+    filtered_data = data_arrays.map { |arr| indices.map { |i| arr[i] } }
+
+    [filtered_dates, *filtered_data]
+  end
 end
 
 # Routes
@@ -98,12 +139,13 @@ get '/api/stock/:ticker' do
   content_type :json
 
   ticker = params[:ticker].upcase
+  period = params[:period] || 'all'
 
   begin
     stock = SQA::Stock.new(ticker: ticker)
     df = stock.df
 
-    # Get price data
+    # Get price data (all data first)
     dates = df["timestamp"].to_a.map(&:to_s)
     opens = df["open_price"].to_a
     highs = df["high_price"].to_a
@@ -111,25 +153,34 @@ get '/api/stock/:ticker' do
     closes = df["adj_close_price"].to_a
     volumes = df["volume"].to_a
 
+    # Filter by period
+    filtered_dates, filtered_opens, filtered_highs, filtered_lows, filtered_closes, filtered_volumes =
+      filter_by_period(dates, opens, highs, lows, closes, volumes, period: period)
+
     # Calculate basic stats
-    current_price = closes.last
-    prev_price = closes[-2]
+    current_price = filtered_closes.last
+    prev_price = filtered_closes[-2]
     change = current_price - prev_price
     change_pct = (change / prev_price) * 100
 
+    # 52-week high/low uses full data for reference
+    high_52w = closes.last(252).max rescue closes.max
+    low_52w = closes.last(252).min rescue closes.min
+
     {
       ticker: ticker,
+      period: period,
       current_price: current_price,
       change: change,
       change_percent: change_pct,
-      high_52w: closes.last(252).max,
-      low_52w: closes.last(252).min,
-      dates: dates,
-      open: opens,
-      high: highs,
-      low: lows,
-      close: closes,
-      volume: volumes
+      high_52w: high_52w,
+      low_52w: low_52w,
+      dates: filtered_dates,
+      open: filtered_opens,
+      high: filtered_highs,
+      low: filtered_lows,
+      close: filtered_closes,
+      volume: filtered_volumes
     }.to_json
   rescue => e
     status 500
@@ -142,6 +193,7 @@ get '/api/indicators/:ticker' do
   content_type :json
 
   ticker = params[:ticker].upcase
+  period = params[:period] || 'all'
 
   begin
     stock = SQA::Stock.new(ticker: ticker)
@@ -152,7 +204,7 @@ get '/api/indicators/:ticker' do
     lows = df["low_price"].to_a
     dates = df["timestamp"].to_a.map(&:to_s)
 
-    # Calculate indicators
+    # Calculate indicators on full dataset (they need historical context)
     rsi = SQAI.rsi(prices, period: 14)
     macd_result = SQAI.macd(prices)
     bb_result = SQAI.bbands(prices)
@@ -160,18 +212,26 @@ get '/api/indicators/:ticker' do
     sma_50 = SQAI.sma(prices, period: 50)
     ema_20 = SQAI.ema(prices, period: 20)
 
+    # Filter results by period (keep indicators aligned with dates)
+    filtered_dates, filtered_rsi, filtered_macd, filtered_macd_signal, filtered_macd_hist,
+      filtered_bb_upper, filtered_bb_middle, filtered_bb_lower, filtered_sma_20, filtered_sma_50, filtered_ema_20 =
+      filter_by_period(dates, rsi, macd_result[0], macd_result[1], macd_result[2],
+                       bb_result[0], bb_result[1], bb_result[2],
+                       sma_20, sma_50, ema_20, period: period)
+
     {
-      dates: dates,
-      rsi: rsi,
-      macd: macd_result[0],        # MACD line
-      macd_signal: macd_result[1], # Signal line
-      macd_hist: macd_result[2],   # Histogram
-      bb_upper: bb_result[0],
-      bb_middle: bb_result[1],
-      bb_lower: bb_result[2],
-      sma_20: sma_20,
-      sma_50: sma_50,
-      ema_20: ema_20
+      period: period,
+      dates: filtered_dates,
+      rsi: filtered_rsi,
+      macd: filtered_macd,
+      macd_signal: filtered_macd_signal,
+      macd_hist: filtered_macd_hist,
+      bb_upper: filtered_bb_upper,
+      bb_middle: filtered_bb_middle,
+      bb_lower: filtered_bb_lower,
+      sma_20: filtered_sma_20,
+      sma_50: filtered_sma_50,
+      ema_20: filtered_ema_20
     }.to_json
   rescue => e
     status 500

--- a/examples/sinatra_app/public/css/style.css
+++ b/examples/sinatra_app/public/css/style.css
@@ -213,6 +213,51 @@ body {
   border-color: var(--primary-color);
 }
 
+/* Period Selector */
+.period-selector {
+  background: var(--card-bg);
+  padding: 1.5rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.period-selector label {
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.75rem;
+  display: block;
+}
+
+.period-buttons {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.btn-period {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  background: white;
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.btn-period:hover {
+  background: var(--light-bg);
+  border-color: var(--primary-color);
+}
+
+.btn-period.active {
+  background: var(--primary-color);
+  color: white;
+  border-color: var(--primary-color);
+}
+
 /* Container */
 .container {
   max-width: 1200px;

--- a/examples/sinatra_app/views/dashboard.erb
+++ b/examples/sinatra_app/views/dashboard.erb
@@ -42,6 +42,21 @@
     </div>
   </div>
 
+  <!-- Time Period Selector -->
+  <div class="period-selector">
+    <label>Time Period:</label>
+    <div class="period-buttons">
+      <button onclick="updatePeriod('30d')" class="btn-period" data-period="30d">30 Days</button>
+      <button onclick="updatePeriod('60d')" class="btn-period" data-period="60d">60 Days</button>
+      <button onclick="updatePeriod('90d')" class="btn-period" data-period="90d">90 Days</button>
+      <button onclick="updatePeriod('1q')" class="btn-period" data-period="1q">1 Quarter</button>
+      <button onclick="updatePeriod('2q')" class="btn-period" data-period="2q">2 Quarters</button>
+      <button onclick="updatePeriod('3q')" class="btn-period" data-period="3q">3 Quarters</button>
+      <button onclick="updatePeriod('4q')" class="btn-period" data-period="4q">4 Quarters</button>
+      <button onclick="updatePeriod('all')" class="btn-period active" data-period="all">All Data</button>
+    </div>
+  </div>
+
   <!-- Main Price Chart -->
   <div class="chart-container">
     <div class="chart-header">
@@ -104,6 +119,7 @@ const ticker = '<%= @ticker %>';
 let stockData = null;
 let indicatorData = null;
 let currentChartType = 'candlestick';
+let currentPeriod = 'all';
 
 // Load data when page loads
 document.addEventListener('DOMContentLoaded', async function() {
@@ -114,7 +130,7 @@ document.addEventListener('DOMContentLoaded', async function() {
 
 async function loadStockData() {
   try {
-    const response = await fetch(`/api/stock/${ticker}`);
+    const response = await fetch(`/api/stock/${ticker}?period=${currentPeriod}`);
     stockData = await response.json();
 
     // Update price info
@@ -141,7 +157,7 @@ async function loadStockData() {
 
 async function loadIndicators() {
   try {
-    const response = await fetch(`/api/indicators/${ticker}`);
+    const response = await fetch(`/api/indicators/${ticker}?period=${currentPeriod}`);
     indicatorData = await response.json();
 
     // Update RSI metric
@@ -411,6 +427,20 @@ async function runStrategyComparison() {
     console.error('Error comparing strategies:', error);
     resultsDiv.innerHTML = '<p class="error">Failed to compare strategies. Please try again.</p>';
   }
+}
+
+async function updatePeriod(period) {
+  currentPeriod = period;
+
+  // Update button states
+  document.querySelectorAll('[data-period]').forEach(btn => {
+    btn.classList.remove('active');
+  });
+  document.querySelector(`[data-period="${period}"]`).classList.add('active');
+
+  // Reload data with new period
+  await loadStockData();
+  await loadIndicators();
 }
 
 function refreshData() {


### PR DESCRIPTION
Users can now filter charts and analysis by time period:
- Day ranges: 30, 60, 90 days
- Quarter ranges: 1Q, 2Q, 3Q, 4Q (based on trading days)
- All data (default)

Backend changes (app.rb):
- Add filter_by_period helper to filter data arrays by date
- Update /api/stock/:ticker to accept period parameter
- Update /api/indicators/:ticker to accept period parameter
- Indicators calculated on full dataset then filtered for accuracy

Frontend changes (dashboard.erb):
- Add period selector buttons above charts
- Update JavaScript to pass period parameter to API calls
- Add updatePeriod() function to reload data when period changes
- Update button states to show active period

UI changes (style.css):
- Add styling for period selector container and buttons
- Consistent button styling with hover and active states

Time period mappings:
- 30d/60d/90d = calendar days
- 1q/2q/3q/4q = 63/126/189/252 trading days (~3/6/9/12 months)