### PR TITLE
fix: Add missing dependencies and error handling to Sinatra app

### DIFF
--- a/examples/sinatra_app/Gemfile
+++ b/examples/sinatra_app/Gemfile
@@ -5,12 +5,32 @@ source 'https://rubygems.org'
 ruby '>= 3.2.0'
 
 # Web framework
+gem 'rackup'
 gem 'sinatra', '~> 4.0'
 gem 'sinatra-contrib', '~> 4.0'
 gem 'puma', '~> 6.0'
 
 # JSON handling
 gem 'json', '~> 2.7'
+
+# SQA library dependencies (required when loading SQA from local path)
+gem 'alphavantage'
+gem 'csv'
+gem 'faraday'
+gem 'hashie'
+gem 'kbs'
+gem 'lite-statistics'
+gem 'nenv'
+gem 'redis'
+gem 'ruby_llm'
+gem 'ruby_llm-mcp'
+gem 'shared_tools'
+gem 'sqa-tai'
+gem 'tty-table'
+gem 'eps'
+gem 'polars-df'
+gem 'toml-rb'
+gem 'regent'
 
 # SQA library (assumes it's in parent directory)
 # In production, this would be:

--- a/examples/sinatra_app/Gemfile.lock
+++ b/examples/sinatra_app/Gemfile.lock
@@ -1,7 +1,48 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    alphavantage (1.2.0)
+      faraday (~> 1.4)
+      hashie (~> 4.1)
     base64 (0.3.0)
+    bigdecimal (3.3.1)
+    citrus (3.0.2)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.4)
+    csv (3.3.5)
+    dentaku (3.5.6)
+      bigdecimal
+      concurrent-ruby
+    eps (0.6.0)
+      lightgbm (>= 0.1.7)
+      matrix
+      nokogiri
+    event_stream_parser (1.0.0)
+    faraday (1.10.4)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.1)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.1.1)
+      multipart-post (~> 2.0)
+    faraday-net_http (1.0.2)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
     ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
@@ -13,17 +54,76 @@ GEM
     ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     ffi (1.17.2-x86_64-linux-musl)
+    fiddle (1.1.8)
+    hashie (4.1.0)
+    http-2 (1.1.1)
+    httpx (1.6.3)
+      http-2 (>= 1.0.0)
     json (2.16.0)
+    json-schema (5.2.2)
+      addressable (~> 2.8)
+      bigdecimal (~> 3.1)
+    kbs (0.1.0)
+      sqlite3 (~> 1.6)
+    lightgbm (0.4.3)
+      ffi
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    lite-memoize (1.1.1)
+    lite-statistics (2.0.0)
+      lite-memoize
     logger (1.7.0)
+    marcel (1.1.0)
+    matrix (0.4.3)
+    mini_portile2 (2.8.9)
     multi_json (1.17.0)
+    multipart-post (2.4.1)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
+    nenv (0.3.0)
     nio4r (2.7.5)
+    nokogiri (1.18.10)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.10-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-musl)
+      racc (~> 1.4)
+    openweathermap (0.2.3)
+    pastel (0.8.0)
+      tty-color (~> 0.5)
+    polars-df (0.23.0)
+      bigdecimal
+      rb_sys
+    polars-df (0.23.0-aarch64-linux)
+      bigdecimal
+    polars-df (0.23.0-aarch64-linux-musl)
+      bigdecimal
+    polars-df (0.23.0-arm64-darwin)
+      bigdecimal
+    polars-df (0.23.0-x86_64-darwin)
+      bigdecimal
+    polars-df (0.23.0-x86_64-linux)
+      bigdecimal
+    polars-df (0.23.0-x86_64-linux-musl)
+      bigdecimal
+    public_suffix (6.0.2)
     puma (6.6.1)
       nio4r (~> 2.0)
+    racc (1.8.1)
     rack (3.2.4)
     rack-protection (4.2.1)
       base64 (>= 0.1.0)
@@ -32,12 +132,51 @@ GEM
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
+    rackup (2.2.1)
+      rack (>= 3)
+    rake-compiler-dock (1.9.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rb_sys (0.9.117)
+      rake-compiler-dock (= 1.9.1)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.26.1)
+      connection_pool
+    regent (0.3.3)
+      pastel (~> 0.8.0)
+      tty-spinner (~> 0.9.3)
+      zeitwerk (~> 2.7)
     rerun (0.14.0)
       listen (~> 3.0)
     ruby2_keywords (0.0.5)
+    ruby_llm (1.9.1)
+      base64
+      event_stream_parser (~> 1)
+      faraday (>= 1.10.0)
+      faraday-multipart (>= 1)
+      faraday-net_http (>= 1)
+      faraday-retry (>= 1)
+      marcel (~> 1.0)
+      ruby_llm-schema (~> 0.2.1)
+      zeitwerk (~> 2)
+    ruby_llm-mcp (0.8.0)
+      httpx (~> 1.4)
+      json-schema (~> 5.0)
+      ruby_llm (~> 1.9)
+      zeitwerk (~> 2)
+    ruby_llm-schema (0.2.4)
+    sequel (5.98.0)
+      bigdecimal
+    shared_tools (0.3.0)
+      dentaku
+      nokogiri
+      openweathermap
+      ruby_llm
+      ruby_llm-mcp
+      sequel
+      zeitwerk
     sinatra (4.2.1)
       logger (>= 1.6.0)
       mustermann (~> 3.0)
@@ -51,7 +190,37 @@ GEM
       rack-protection (= 4.2.1)
       sinatra (= 4.2.1)
       tilt (~> 2.0)
+    sqa-tai (0.1.0)
+      ta_lib_ffi (~> 0.3)
+    sqlite3 (1.7.3-aarch64-linux)
+    sqlite3 (1.7.3-arm-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86-linux)
+    sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
+    strings (0.2.1)
+      strings-ansi (~> 0.2)
+      unicode-display_width (>= 1.5, < 3.0)
+      unicode_utils (~> 1.4)
+    strings-ansi (0.2.0)
+    ta_lib_ffi (0.3.0)
+      fiddle (~> 1.1)
     tilt (2.6.1)
+    toml-rb (4.1.0)
+      citrus (~> 3.0, > 3.0)
+      racc (~> 1.7)
+    tty-color (0.6.0)
+    tty-cursor (0.7.1)
+    tty-screen (0.8.2)
+    tty-spinner (0.9.3)
+      tty-cursor (~> 0.7)
+    tty-table (0.12.0)
+      pastel (~> 0.8)
+      strings (~> 0.2.0)
+      tty-screen (~> 0.8)
+    unicode-display_width (2.6.0)
+    unicode_utils (1.4.0)
+    zeitwerk (2.7.3)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -59,7 +228,6 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin
-  ruby
   x86-linux-gnu
   x86-linux-musl
   x86_64-darwin
@@ -67,11 +235,29 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  alphavantage
+  csv
+  eps
+  faraday
+  hashie
   json (~> 2.7)
+  kbs
+  lite-statistics
+  nenv
+  polars-df
   puma (~> 6.0)
+  rackup
+  redis
+  regent
   rerun
+  ruby_llm
+  ruby_llm-mcp
+  shared_tools
   sinatra (~> 4.0)
   sinatra-contrib (~> 4.0)
+  sqa-tai
+  toml-rb
+  tty-table
 
 RUBY VERSION
    ruby 3.3.6p108

--- a/examples/sinatra_app/views/dashboard.erb
+++ b/examples/sinatra_app/views/dashboard.erb
@@ -164,7 +164,18 @@ async function loadStockData() {
 async function loadIndicators() {
   try {
     const response = await fetch(`/api/indicators/${ticker}?period=${currentPeriod}`);
-    indicatorData = await response.json();
+    const data = await response.json();
+
+    // Check if API returned an error
+    if (data.error) {
+      console.warn('Indicators not available:', data.error);
+      document.getElementById('currentRSI').textContent = 'N/A';
+      document.getElementById('rsiSignal').textContent = 'TA-Lib not installed';
+      document.getElementById('rsiSignal').className = 'metric-signal';
+      return;
+    }
+
+    indicatorData = data;
 
     // Update RSI metric
     const currentRSI = indicatorData.rsi[indicatorData.rsi.length - 1];
@@ -191,6 +202,8 @@ async function loadIndicators() {
     renderMACDChart();
   } catch (error) {
     console.error('Error loading indicators:', error);
+    document.getElementById('currentRSI').textContent = 'Error';
+    document.getElementById('rsiSignal').textContent = 'Failed to load';
   }
 }
 
@@ -483,6 +496,12 @@ function renderRSIChart() {
     rsiChart.destroy();
   }
 
+  // Skip if indicators not available
+  if (!indicatorData || !indicatorData.rsi) {
+    document.querySelector("#rsiChart").innerHTML = '<p style="text-align: center; padding: 40px; color: #9fa8da;">Technical indicators not available (TA-Lib required)</p>';
+    return;
+  }
+
   const options = {
     series: [
       {
@@ -589,6 +608,12 @@ function renderMACDChart() {
   // Destroy existing chart if it exists
   if (macdChart) {
     macdChart.destroy();
+  }
+
+  // Skip if indicators not available
+  if (!indicatorData || !indicatorData.macd) {
+    document.querySelector("#macdChart").innerHTML = '<p style="text-align: center; padding: 40px; color: #9fa8da;">Technical indicators not available (TA-Lib required)</p>';
+    return;
   }
 
   // Prepare histogram data with colors


### PR DESCRIPTION
The Sinatra app was hanging on the dashboard page due to:
1. Missing gem dependencies (faraday, redis, kbs, etc.)
2. Lack of error handling when TA-Lib indicators fail

Changes:
- Added all SQA library dependencies to Gemfile
- Added rackup gem for Sinatra 4.0
- Improved error handling in dashboard.erb for failed indicator API calls
- Display friendly error messages instead of hanging when TA-Lib not installed

The app now loads successfully and gracefully handles missing TA-Lib.