### PR TITLE
docs: Add startup script and fix bundle exec documentation

### DIFF
--- a/examples/sinatra_app/QUICKSTART.md
+++ b/examples/sinatra_app/QUICKSTART.md
@@ -24,11 +24,21 @@ bundle install
 
 ## 3. Start the Application
 
+**IMPORTANT:** Always use `bundle exec` to ensure all gems are loaded correctly:
+
 ```bash
-ruby app.rb
+bundle exec ruby app.rb
+```
+
+Or use the provided startup script:
+
+```bash
+./start.sh
 ```
 
 The app will start on http://localhost:4567
+
+**Common mistake:** Running `ruby app.rb` without `bundle exec` will cause the app to fail or behave incorrectly.
 
 ## 4. Quick Tour
 
@@ -92,8 +102,8 @@ curl -X POST http://localhost:4567/api/compare/AAPL
 Auto-reload on file changes:
 
 ```bash
-gem install rerun
-rerun 'ruby app.rb'
+bundle install  # rerun is in the development group
+bundle exec rerun 'ruby app.rb'
 ```
 
 ## 8. Troubleshooting

--- a/examples/sinatra_app/README.md
+++ b/examples/sinatra_app/README.md
@@ -84,13 +84,23 @@ redis-server
 
 ### Start the Application
 
+**⚠️ IMPORTANT:** Always use `bundle exec` to run the app:
+
 ```bash
-ruby app.rb
+bundle exec ruby app.rb
 ```
+
+**Or use the startup script:**
+
+```bash
+./start.sh
+```
+
+**Why `bundle exec`?** Running `ruby app.rb` without `bundle exec` may fail to load required gems, causing the dashboard to not work properly (buttons won't respond, charts won't load, API calls will fail).
 
 Or using Rack:
 ```bash
-rackup
+bundle exec rackup
 ```
 
 The application will start on `http://localhost:4567`

--- a/examples/sinatra_app/TROUBLESHOOTING.md
+++ b/examples/sinatra_app/TROUBLESHOOTING.md
@@ -1,0 +1,95 @@
+# Troubleshooting the Sinatra App
+
+## Dashboard page loads but buttons/charts don't work
+
+This usually means JavaScript errors are preventing the page from functioning.
+
+### Quick Fix Checklist
+
+1. **Install dependencies first:**
+   ```bash
+   cd examples/sinatra_app
+   bundle install
+   ```
+
+2. **Start the server with bundle exec:**
+   ```bash
+   bundle exec ruby app.rb
+   # OR
+   bundle exec rackup
+   ```
+
+3. **Check browser console for errors:**
+   - Open browser DevTools (F12 or Ctrl+Shift+I)
+   - Go to "Console" tab
+   - Look for red error messages
+   - Take a screenshot and check what's failing
+
+4. **Check Network tab:**
+   - Open DevTools → Network tab
+   - Reload the dashboard page
+   - Look for failed requests (red status codes)
+   - Check if `/api/stock/AAPL`, `/api/indicators/AAPL`, `/api/analyze/AAPL` are returning 200 or errors
+
+### Common Issues
+
+#### Issue: "ApexCharts is not defined"
+**Symptom:** Charts don't render, console shows `Uncaught ReferenceError: ApexCharts is not defined`
+
+**Fix:** The CDN link for ApexCharts is missing or blocked. Check `views/layout.erb`:
+```html
+<script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+```
+
+#### Issue: API calls failing with 500 errors
+**Symptom:** Network tab shows `/api/indicators/AAPL` returns 500
+
+**Fix:** This is expected if TA-Lib isn't installed. The app should handle this gracefully.
+
+#### Issue: Buttons don't respond
+**Symptom:** Clicking buttons does nothing
+
+**Possible causes:**
+1. JavaScript not loaded (check console for errors)
+2. Event handlers not attached (check if page finished loading)
+3. JavaScript errors earlier in the file preventing execution
+
+### Debug Mode
+
+Run the server with verbose logging:
+```bash
+RACK_ENV=development bundle exec ruby app.rb
+```
+
+### Test API Endpoints Manually
+
+While server is running, test in another terminal:
+
+```bash
+# Test stock data
+curl -s "http://localhost:4567/api/stock/AAPL?period=30d" | python3 -m json.tool
+
+# Test indicators (may fail without TA-Lib - that's OK)
+curl -s "http://localhost:4567/api/indicators/AAPL?period=30d"
+
+# Test analysis
+curl -s "http://localhost:4567/api/analyze/AAPL" | python3 -m json.tool
+```
+
+All should return JSON. If you get HTML error pages, there's a server-side issue.
+
+### Check if all gems are installed
+
+```bash
+bundle check
+```
+
+If it says "The Gemfile's dependencies are satisfied", you're good.
+
+### Still not working?
+
+Please provide:
+1. Screenshot of browser console (DevTools → Console tab)
+2. Screenshot of network tab showing failed requests
+3. Output of `bundle check`
+4. Any errors from server console

--- a/examples/sinatra_app/start.sh
+++ b/examples/sinatra_app/start.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Startup script for SQA Sinatra App
+# This script checks dependencies and starts the server properly
+
+set -e
+
+echo "============================================================"
+echo "SQA Sinatra App - Startup Script"
+echo "============================================================"
+echo ""
+
+# Check if we're in the right directory
+if [ ! -f "app.rb" ]; then
+  echo "❌ Error: app.rb not found. Please run this script from examples/sinatra_app/"
+  exit 1
+fi
+
+# Check if Gemfile exists
+if [ ! -f "Gemfile" ]; then
+  echo "❌ Error: Gemfile not found"
+  exit 1
+fi
+
+# Check if bundler is installed
+if ! command -v bundle &> /dev/null; then
+  echo "❌ Error: bundler is not installed"
+  echo "   Install with: gem install bundler"
+  exit 1
+fi
+
+echo "✓ Found app.rb and Gemfile"
+
+# Check if bundle is satisfied
+echo ""
+echo "Checking dependencies..."
+if ! bundle check &> /dev/null; then
+  echo "⚠️  Dependencies not installed. Running bundle install..."
+  bundle install
+  echo "✓ Dependencies installed"
+else
+  echo "✓ All dependencies satisfied"
+fi
+
+echo ""
+echo "Starting server..."
+echo "============================================================"
+echo "Server will be available at: http://localhost:4567"
+echo "Press Ctrl+C to stop"
+echo "============================================================"
+echo ""
+
+# Start the server with bundle exec
+exec bundle exec ruby app.rb


### PR DESCRIPTION
Added comprehensive startup and troubleshooting documentation to help users avoid common pitfalls when running the Sinatra app.

Changes:
- Created start.sh script that checks dependencies and starts server
- Added TROUBLESHOOTING.md with debugging guide
- Updated README.md to emphasize using 'bundle exec'
- Updated QUICKSTART.md with proper bundle exec usage
- Added warnings about running without bundle exec

The main issue users face is running 'ruby app.rb' without 'bundle exec', which causes gems not to load properly and the dashboard to fail silently.