### PR TITLE
fix: Change CSV sort order to ascending for TA-Lib compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,27 @@ sqa-console        # Launch IRB with SQA library loaded
 - 150+ indicators available: SMA, EMA, RSI, MACD, Bollinger Bands, ADX, ATR, etc.
 - See: https://github.com/MadBomber/sqa-tai
 
+### Data Ordering (CRITICAL)
+**TA-Lib Requirement**: Arrays MUST be in **OLDEST-FIRST** (ascending chronological) order
+- Index [0] = oldest data point
+- Index [last] = newest/most recent data point
+- This applies to ALL TA-Lib indicators
+
+**SQA Implementation**:
+- ✅ CSV files stored in **ASCENDING order** (oldest-first) for TA-Lib compatibility
+- ✅ DataFrames maintain ascending order after updates
+- ✅ `.to_a` extracts arrays ready for TA-Lib (no reversal needed)
+- ✅ `concat_and_deduplicate!` sorts ascending by default
+- ⚠️ Alpha Vantage API returns data newest-first, but SQA automatically sorts to ascending
+
+**Example**:
+```ruby
+prices = stock.df["adj_close_price"].to_a
+# => [100.0, 101.5, 103.2, ...]  (oldest to newest - ready for TA-Lib)
+
+rsi = SQAI.rsi(prices, period: 14)  # Correct order, no reversal needed
+```
+
 ### Testing Approach
 - Minitest framework in `/test/` directory
 - SimpleCov for coverage reporting

--- a/lib/sqa/data_frame.rb
+++ b/lib/sqa/data_frame.rb
@@ -82,8 +82,8 @@ class SQA::DataFrame
   #
   # @param other_df [SQA::DataFrame] DataFrame to append
   # @param sort_column [String] Column to use for deduplication and sorting (default: "timestamp")
-  # @param descending [Boolean] Sort order - true for descending (newest first), false for ascending
-  def concat_and_deduplicate!(other_df, sort_column: "timestamp", descending: true)
+  # @param descending [Boolean] Sort order - false for ascending (oldest first, TA-Lib compatible), true for descending
+  def concat_and_deduplicate!(other_df, sort_column: "timestamp", descending: false)
     # Concatenate the dataframes
     @data = if @data.shape[0] == 0
               other_df.data

--- a/lib/sqa/data_frame/alpha_vantage.rb
+++ b/lib/sqa/data_frame/alpha_vantage.rb
@@ -35,9 +35,14 @@ class SQA::DataFrame
 
     ################################################################
 
-    # Get recent data from JSON API
+    # Get recent data from Alpha Vantage API
+    #
     # ticker String the security to retrieve
-    # returns a Polars DataFrame
+    # full Boolean whether to fetch full history or compact (last 100 days)
+    # from_date Date optional date to fetch data after (for incremental updates)
+    #
+    # Returns: SQA::DataFrame sorted in ASCENDING order (oldest to newest)
+    # Note: Alpha Vantage returns data newest-first, but we sort ascending for TA-Lib compatibility
     def self.recent(ticker, full: false, from_date: nil)
       response  = CONNECTION.get(
         "/query?" +
@@ -80,6 +85,10 @@ class SQA::DataFrame
       sqa_df.data = sqa_df.data.with_column(
         sqa_df.data["close_price"].alias("adj_close_price")
       )
+
+      # Sort data in ascending chronological order (oldest to newest) for TA-Lib compatibility
+      # Alpha Vantage returns data newest-first, but TA-Lib expects oldest-first
+      sqa_df.data = sqa_df.data.sort("timestamp", reverse: false)
 
       sqa_df
     end

--- a/lib/sqa/stock.rb
+++ b/lib/sqa/stock.rb
@@ -116,12 +116,12 @@ class SQA::Stock
     return unless should_update?
 
     begin
-      # CSV is sorted descending (newest first), so .first gets the most recent date
-      from_date = Date.parse(@df["timestamp"].to_a.first)
+      # CSV is sorted ascending (oldest first, TA-Lib compatible), so .last gets the most recent date
+      from_date = Date.parse(@df["timestamp"].to_a.last)
       df2 = @klass.recent(@ticker, from_date: from_date)
 
       if df2 && (df2.size > 0)
-        # Use concat_and_deduplicate! to prevent duplicate timestamps
+        # Use concat_and_deduplicate! to prevent duplicate timestamps and maintain ascending sort
         @df.concat_and_deduplicate!(df2)
         @df.to_csv(@df_path)
       end
@@ -151,6 +151,8 @@ class SQA::Stock
   def to_s
     "#{ticker} with #{@df.size} data points from #{@df["timestamp"].to_a.first} to #{@df["timestamp"].to_a.last}"
   end
+  # Note: CSV data is stored in ascending chronological order (oldest to newest)
+  # This ensures compatibility with TA-Lib indicators which expect arrays in this order
   alias_method :inspect, :to_s
 
   def merge_overview


### PR DESCRIPTION
CRITICAL: TA-Lib requires arrays in OLDEST-FIRST (ascending) order. Previous implementation used descending order, causing all indicator calculations to be incorrect.

Changes made:

1. DataFrame#concat_and_deduplicate! default changed to ascending
   - Was: descending: true (newest first)
   - Now: descending: false (oldest first, TA-Lib compatible)

2. Stock#update_dataframe_with_recent_data fixed
   - Changed from .first to .last to get most recent date
   - Updated comment to reflect ascending order

3. AlphaVantage adapter explicitly sorts ascending
   - Added sort after fetching data
   - AV returns newest-first, we need oldest-first
   - Added comprehensive documentation

4. Updated all tests for ascending order
   - test_concat_and_deduplicate_maintains_ascending_order (renamed)
   - test_concat_and_deduplicate_descending_order (new, tests override)
   - All test data updated to reflect ascending default

5. Documentation updates
   - Added "Data Ordering (CRITICAL)" section to CLAUDE.md
   - Explains TA-Lib requirements
   - Shows correct usage examples
   - Added comments throughout codebase

Impact:
- CSV files now stored oldest-to-newest (e.g., [2020-01-01, ..., 2024-11-12])
- Arrays extracted with .to_a are ready for TA-Lib (no reversal needed)
- All technical indicators will now calculate correctly
- BREAKING CHANGE: Existing CSV files need to be re-sorted

Migration:
Users should run data cleaning script to reverse existing CSV files or delete them and re-fetch (will auto-sort correctly).

All tests passing (15 runs, 21 assertions, 0 failures, 0 errors)